### PR TITLE
Update sample_052.md

### DIFF
--- a/samples/sample_052.md
+++ b/samples/sample_052.md
@@ -276,7 +276,7 @@ PROCEDURE ReceiveDatagram
 
 PROTECTED FUNCTION GetBindBuf(cIP, nPort)
 	LOCAL cBuffer, cPort, cHost
-	cPort = num2word(htons(nPort))
+	cPort = num2word(BitClear(htons(nPort),16))
 	cHost = num2dword(inet_addr(cIP))
 RETURN num2word(AF_INET) + cPort + cHost + REPLICATE(CHR(0),8)
 


### PR DESCRIPTION
On newer Windows Systems hton returns numbers with the 16th bit set.

Example:
htons(461) => 53505 (32bit Systems)
htons(461) => 119041 (64bit Systems / newer Windows Versions)

Checking this in binary:
53505  => 01101000100000001
119041 => 11101000100000001

When removing the 16th bit by bitclear the code works as supposed