### PR TITLE
htons / num2word fails on newer Windows x64 Systems

### DIFF
--- a/libraries/ws2_32/htons.md
+++ b/libraries/ws2_32/htons.md
@@ -50,3 +50,29 @@ hostshort
 The htons function returns the value in TCP/IP network byte order.  
 ***  
 
+## Hints:
+On newer Windows Systems htons returns 16th bit set.
+Example:
+```foxpro  
+? htons(465)
+```
+This returns on 32bit Systems the Value 53505, on 64bit Systems on newer Windows Version it returns 119041.
+When converting to binary it is clear, that the 16th bit is set
+```
+01101000100000001 -> 53505
+11101000100000001 -> 119041
+```
+This causes some code to fail when the num2word function is used:
+```foxpro
+  FUNCTION num2word(lnValue)
+  RETURN Chr(MOD(m.lnValue,256)) + CHR(INT(m.lnValue/256))
+```
+To resolve this (code is working after as excepted) clear the 16th bit:
+```foxpro
+  FUNCTION num2word(lnValue)
+  lnValue = BITCLEAR(lnValue,16)
+  RETURN Chr(MOD(m.lnValue,256)) + CHR(INT(m.lnValue/256))
+```
+
+***  
+

--- a/samples/sample_052.md
+++ b/samples/sample_052.md
@@ -276,7 +276,7 @@ PROCEDURE ReceiveDatagram
 
 PROTECTED FUNCTION GetBindBuf(cIP, nPort)
 	LOCAL cBuffer, cPort, cHost
-	cPort = num2word(htons(nPort))
+	cPort = num2word(BitClear(htons(nPort),16))
 	cHost = num2dword(inet_addr(cIP))
 RETURN num2word(AF_INET) + cPort + cHost + REPLICATE(CHR(0),8)
 

--- a/samples/sample_383.md
+++ b/samples/sample_383.md
@@ -96,7 +96,7 @@ PROCEDURE HTTPGetData(cUrl)
 FUNCTION ConnectTo(hSocket, cHostIP, nPort)
 * connects to remote host through a specified socket
 	LOCAL cBuffer, cPort, cHost
-	cPort = num2word(htons(nPort))
+	cPort = num2word(BitClear(htons(nPort),16))
 	nHost = inet_addr(cHostIP)
 	cHost = num2dword(nHost)
 	cBuffer = num2word(AF_INET) + cPort + cHost + Repli(Chr(0),8)

--- a/samples/sample_385.md
+++ b/samples/sample_385.md
@@ -137,7 +137,7 @@ RETURN inet_ntoa(buf2dword(m.cIP))
 
 PROTECTED FUNCTION ConnectTo
 	LOCAL cBuffer, cPort, cHost, lResult
-	cPort = num2word(htons(SMTP_PORT))
+	cPort = num2word(BitClear(htons(SMTP_PORT),16))
 	nHost = inet_addr(THIS.IP)
 	cHost = num2dword(nHost)
 	cBuffer = num2word(AF_INET) + cPort + cHost + REPLICATE(CHR(0),8)

--- a/samples/sample_386.md
+++ b/samples/sample_386.md
@@ -102,7 +102,7 @@ RETURN lResult
 PROTECTED FUNCTION cn(hSocket, cIP, nPort)
 	LOCAL cBuffer, nResult
 	cBuffer = num2word(AF_INET) +;
-		num2word(htons(nPort)) +;
+		num2word(BitClear(htons(nPort),16)) +;
 		num2dword(inet_addr(cIP)) + Repli(Chr(0),8)
 	nResult = ws_connect(hSocket, @cBuffer, Len(cBuffer))
 RETURN (nResult = 0)

--- a/samples/sample_388.md
+++ b/samples/sample_388.md
@@ -122,7 +122,7 @@ RETURN lResult
 PROTECTED FUNCTION cn(hSocket, cIP, nPort)
 	LOCAL cBuffer, nResult
 	cBuffer = num2word(AF_INET) +;
-		num2word(htons(nPort)) +;
+		num2word(BitClear(htons(nPort),16)) +;
 		num2dword(inet_addr(cIP)) + Repli(Chr(0),8)
 	nResult = ws_connect(hSocket, @cBuffer, Len(cBuffer))
 RETURN (nResult = 0)

--- a/samples/sample_389.md
+++ b/samples/sample_389.md
@@ -104,7 +104,7 @@ RETURN lResult
 PROTECTED FUNCTION cn(hSocket, cIP, nPort)
 	LOCAL cBuffer, nResult
 	cBuffer = num2word(AF_INET) +;
-		num2word(htons(nPort)) +;
+		num2word(BitClear(htons(nPort),16)) +;
 		num2dword(inet_addr(cIP)) + Repli(CHR(0),8)
 
 	nResult = WSAConnect(hSocket, @cBuffer, Len(cBuffer), 0, 0, 0, 0)

--- a/samples/sample_412.md
+++ b/samples/sample_412.md
@@ -232,7 +232,7 @@ RETURN nCount <> 0 And (buf2dword(SUBSTR(cRead,1,4)) > 0)
 
 FUNCTION GetBindBuf(cIP, nPort)
 	LOCAL cBuffer, cPort, cHost
-	cPort = num2word(htons(nPort))
+	cPort = num2word(BitClear(htons(nPort),16))
 	cHost = num2dword(inet_addr(cIP))
 RETURN num2word(AF_INET) + cPort + cHost + Repli(Chr(0),8)
 

--- a/samples/sample_570.md
+++ b/samples/sample_570.md
@@ -79,7 +79,7 @@ RETURN (nInitResult=0)
 FUNCTION GetSocaddrIn(cIP As String,;
 	nPort As Number) As String
 	LOCAL cBuffer, cPort, cHost
-	cPort = num2word(htons(nPort))
+	cPort = num2word(BitClear(htons(nPort),16))
 	cHost = num2dword(inet_addr(cIP))
 RETURN num2word(AF_INET) + m.cPort +;
 	m.cHost + REPLICATE(CHR(0),8)


### PR DESCRIPTION
On newer Windows Systems hton returns numbers with the 16th bit set.

Example:
htons(461) => 53505 (32bit Systems)
htons(461) => 119041 (64bit Systems / newer Windows Versions)

Checking this in binary:
53505 => 01101000100000001
119041 => 11101000100000001

When removing the 16th bit by bitclear the code works as supposed