### PR TITLE
Replace backticks (`) with apostrophes (')

### DIFF
--- a/Libraries.md
+++ b/Libraries.md
@@ -1079,17 +1079,17 @@ The FrameRgn function draws a border around the specified region by using the sp
 ***  
 
 [GdiFlush](libraries/gdi32/GdiFlush.md)  
-Flushes the calling thread`s current batch.  
+Flushes the calling thread's current batch.  
 
 ***  
 
 [GdiGetBatchLimit](libraries/gdi32/GdiGetBatchLimit.md)  
-Returns the maximum number of function calls that can be accumulated in the calling thread`s current batch.   
+Returns the maximum number of function calls that can be accumulated in the calling thread's current batch.   
 
 ***  
 
 [GdiSetBatchLimit](libraries/gdi32/GdiSetBatchLimit.md)  
-Sets the maximum number of function calls that can be accumulated in the calling thread`s current batch. The system flushes the current batch whenever this limit is exceeded.   
+Sets the maximum number of function calls that can be accumulated in the calling thread's current batch. The system flushes the current batch whenever this limit is exceeded.   
 
 ***  
 
@@ -1760,7 +1760,7 @@ Sets the unit of measure for this Graphics handle.
 ***  
 
 [GdipSetPathGradientCenterColor](libraries/gdiplus/GdipSetPathGradientCenterColor.md)  
-Sets the center color of this path gradient brush. The center color is the color that appears at the brush`s center point.  
+Sets the center color of this path gradient brush. The center color is the color that appears at the brush's center point.  
 
 ***  
 
@@ -3680,7 +3680,7 @@ Adds a user account and assigns a password and privilege level.
 ***  
 
 [NetUserChangePassword](libraries/netapi32/NetUserChangePassword.md)  
-Changes user`s password for a specified network server or domain.
+Changes user's password for a specified network server or domain.
   
 
 ***  

--- a/functions_alphabetical.md
+++ b/functions_alphabetical.md
@@ -1699,12 +1699,12 @@ Changes to a different working directory on the FTP server
 
 ## [<img src="images/home.png"> Home ](https://github.com/VFPX/Win32API)[A ](#A)[B ](#B)[C ](#C)[D ](#D)[E ](#E)[F ](#F)[G ](#G)[H ](#H)[I ](#I)[J ](#J)[K ](#K)[L ](#L)[M ](#M)[N ](#N)[O ](#O)[P ](#P)[Q ](#Q)[R ](#R)[S ](#S)[T ](#T)[U ](#U)[V ](#V)[W ](#W)[Z ](#Z)[_ ](#_)
 <a name="G"></a>[GdiFlush](libraries/gdi32/GdiFlush.md)  
-Flushes the calling thread`s current batch.  
+Flushes the calling thread's current batch.  
 
 ***  
 
 [GdiGetBatchLimit](libraries/gdi32/GdiGetBatchLimit.md)  
-Returns the maximum number of function calls that can be accumulated in the calling thread`s current batch.   
+Returns the maximum number of function calls that can be accumulated in the calling thread's current batch.   
 
 ***  
 
@@ -2175,7 +2175,7 @@ Sets the unit of measure for this Graphics handle.
 ***  
 
 [GdipSetPathGradientCenterColor](libraries/gdiplus/GdipSetPathGradientCenterColor.md)  
-Sets the center color of this path gradient brush. The center color is the color that appears at the brush`s center point.  
+Sets the center color of this path gradient brush. The center color is the color that appears at the brush's center point.  
 
 ***  
 
@@ -2223,7 +2223,7 @@ Updates this Graphics object"s world transformation matrix with the product of i
 ***  
 
 [GdiSetBatchLimit](libraries/gdi32/GdiSetBatchLimit.md)  
-Sets the maximum number of function calls that can be accumulated in the calling thread`s current batch. The system flushes the current batch whenever this limit is exceeded.   
+Sets the maximum number of function calls that can be accumulated in the calling thread's current batch. The system flushes the current batch whenever this limit is exceeded.   
 
 ***  
 
@@ -4648,7 +4648,7 @@ Adds a user account and assigns a password and privilege level.
 ***  
 
 [NetUserChangePassword](libraries/netapi32/NetUserChangePassword.md)  
-Changes user`s password for a specified network server or domain.
+Changes user's password for a specified network server or domain.
   
 
 ***  

--- a/functions_group.md
+++ b/functions_group.md
@@ -2224,7 +2224,7 @@ Creates a PathGradient Brush object based on an array of points. Initializes the
 ***  
 
 [GdipSetPathGradientCenterColor](libraries/gdiplus/GdipSetPathGradientCenterColor.md)  
-Sets the center color of this path gradient brush. The center color is the color that appears at the brush`s center point.  
+Sets the center color of this path gradient brush. The center color is the color that appears at the brush's center point.  
 
 ***  
 
@@ -3738,7 +3738,7 @@ Adds a user account and assigns a password and privilege level.
 ***  
 
 [NetUserChangePassword](libraries/netapi32/NetUserChangePassword.md)  
-Changes user`s password for a specified network server or domain.
+Changes user's password for a specified network server or domain.
   
 
 ***  
@@ -3977,17 +3977,17 @@ The DrawFrameControl function draws a frame control of the specified type and st
 ***  
 
 [GdiFlush](libraries/gdi32/GdiFlush.md)  
-Flushes the calling thread`s current batch.  
+Flushes the calling thread's current batch.  
 
 ***  
 
 [GdiGetBatchLimit](libraries/gdi32/GdiGetBatchLimit.md)  
-Returns the maximum number of function calls that can be accumulated in the calling thread`s current batch.   
+Returns the maximum number of function calls that can be accumulated in the calling thread's current batch.   
 
 ***  
 
 [GdiSetBatchLimit](libraries/gdi32/GdiSetBatchLimit.md)  
-Sets the maximum number of function calls that can be accumulated in the calling thread`s current batch. The system flushes the current batch whenever this limit is exceeded.   
+Sets the maximum number of function calls that can be accumulated in the calling thread's current batch. The system flushes the current batch whenever this limit is exceeded.   
 
 ***  
 

--- a/libraries/comdlg32/PrintDlgEx.md
+++ b/libraries/comdlg32/PrintDlgEx.md
@@ -47,7 +47,7 @@ The Print property sheet has the General page with controls similar to the Print
   
 The property sheet can also have additional application-specific and driver-specific property pages following the General page.  
   
-When the PrintDlgEx returns, the PRINTDLGEX structure contains information about the user`s selections.   
+When the PrintDlgEx returns, the PRINTDLGEX structure contains information about the user's selections.   
   
 On successful return the dwResultAction member of the PRINTDLGEX structure contains one of the following values: PD_RESULT_APPLY, PD_RESULT_CANCEL, PD_RESULT_PRINT.  
   

--- a/libraries/gdi32/GdiFlush.md
+++ b/libraries/gdi32/GdiFlush.md
@@ -5,7 +5,7 @@ Group: [Painting and Drawing](../../functions_group.md#Painting_and_Drawing)  - 
 ***  
 
 
-#### Flushes the calling thread`s current batch.
+#### Flushes the calling thread's current batch.
 ***  
 
 

--- a/libraries/gdi32/GdiGetBatchLimit.md
+++ b/libraries/gdi32/GdiGetBatchLimit.md
@@ -5,7 +5,7 @@ Group: [Painting and Drawing](../../functions_group.md#Painting_and_Drawing)  - 
 ***  
 
 
-#### Returns the maximum number of function calls that can be accumulated in the calling thread`s current batch. 
+#### Returns the maximum number of function calls that can be accumulated in the calling thread's current batch. 
 ***  
 
 

--- a/libraries/gdi32/GdiSetBatchLimit.md
+++ b/libraries/gdi32/GdiSetBatchLimit.md
@@ -5,7 +5,7 @@ Group: [Painting and Drawing](../../functions_group.md#Painting_and_Drawing)  - 
 ***  
 
 
-#### Sets the maximum number of function calls that can be accumulated in the calling thread`s current batch. The system flushes the current batch whenever this limit is exceeded. 
+#### Sets the maximum number of function calls that can be accumulated in the calling thread's current batch. The system flushes the current batch whenever this limit is exceeded. 
 ***  
 
 

--- a/libraries/gdiplus/GdipSetPathGradientCenterColor.md
+++ b/libraries/gdiplus/GdipSetPathGradientCenterColor.md
@@ -5,7 +5,7 @@ Group: [GDI+ PathGradient Brush](../../functions_group.md#GDIplus_PathGradient_B
 ***  
 
 
-#### Sets the center color of this path gradient brush. The center color is the color that appears at the brush`s center point.
+#### Sets the center color of this path gradient brush. The center color is the color that appears at the brush's center point.
 ***  
 
 

--- a/libraries/kernel32/CopyFileTransacted.md
+++ b/libraries/kernel32/CopyFileTransacted.md
@@ -75,7 +75,7 @@ Requires Windows Vista.
   
 Obviously the callback side of this function cannot be exploited in plain FoxPro code. Thus the <Em>lpProgressRoutine</Em> must be set to 0.  
   
-Based on call`s completion (also some application logic may become involved), either CommitTransaction or RollbackTransaction is applied to finalize or cancel the process of copying.  
+Based on call's completion (also some application logic may become involved), either CommitTransaction or RollbackTransaction is applied to finalize or cancel the process of copying.  
   
 See also: [CreateTransaction](../ktmw32/CreateTransaction.md), [CommitTransaction](../ktmw32/CommitTransaction.md), [RollbackTransaction](../ktmw32/RollbackTransaction.md), [CopyFile](../kernel32/CopyFile.md), [DeleteFileTransacted](../kernel32/DeleteFileTransacted.md).  
   

--- a/libraries/kernel32/GetLastError.md
+++ b/libraries/kernel32/GetLastError.md
@@ -34,7 +34,7 @@ Group: [Error Handling](../../functions_group.md#Error_Handling)  -  Library: [k
 [DiskFreeSpace class](../../samples/sample_100.md)  
 [Obtaining physical parameters for a drive: sectors, clusters, cylinders...](../../samples/sample_101.md)  
 [Wininet last error description](../../samples/sample_109.md)  
-[How to download this reference`s archive through WinInet functions using InternetOpenUrl](../../samples/sample_110.md)  
+[How to download this reference's archive through WinInet functions using InternetOpenUrl](../../samples/sample_110.md)  
 [Setting the Window Region for a form](../../samples/sample_120.md)  
 [How to initiate System shutdown](../../samples/sample_122.md)  
 [Finding parameters for the region specified](../../samples/sample_124.md)  

--- a/libraries/kernel32/LoadResource.md
+++ b/libraries/kernel32/LoadResource.md
@@ -51,9 +51,9 @@ If the function succeeds, the return value is a handle to the data associated wi
 If <Em>hModule</Em> is NULL, the system loads resource from the module that was used to create current process.   
   
 * * *  
-I am thinking about approaches to design of VFP application with auto-updateable executable, the master copy of which is stored on a web server. Definitely I am not the first person doing this -- read Rick Strahl`s article <a href="http://www.west-wind.com/presentations/wwCodeUpdate/codeupdate.asp">Automatic Application Updates over the Web with Visual FoxPro 7.0</a> -- so my thoughts may not be precisely original.  
+I am thinking about approaches to design of VFP application with auto-updateable executable, the master copy of which is stored on a web server. Definitely I am not the first person doing this -- read Rick Strahl's article <a href="http://www.west-wind.com/presentations/wwCodeUpdate/codeupdate.asp">Automatic Application Updates over the Web with Visual FoxPro 7.0</a> -- so my thoughts may not be precisely original.  
   
-Normally Windows executable can not update itself. That means it needs help from another process; let`s call this one the Updating Process.   
+Normally Windows executable can not update itself. That means it needs help from another process; let's call this one the Updating Process.   
   
 Six tasks for UP to get done:  
 - connect to the web server and check for updates  

--- a/libraries/kernel32/SetFilePointerEx.md
+++ b/libraries/kernel32/SetFilePointerEx.md
@@ -59,7 +59,7 @@ Note that the number of parameters is different in C and VFP declarations for th
   
 My first intention was to declare the second parameter, <Em>liDistanceToMove</Em>, as STRING @, which is the pointer to string. This approach worked in similar situations before but failed in this particular case.  
   
-Calvin Hsia in <a href="http://blogs.msdn.com/calvin_hsia/archive/2005/03/18/398749.aspx">his blog`s entry</a> explains why this function must be declared in VFP with rather five input parameters versus four regular ones.  
+Calvin Hsia in <a href="http://blogs.msdn.com/calvin_hsia/archive/2005/03/18/398749.aspx">his blog's entry</a> explains why this function must be declared in VFP with rather five input parameters versus four regular ones.  
   
 The long integer (8 bytes) input parameter <Em>liDistanceToMove</Em> is passed to this function as two separate input parameters of LONG type (4 bytes each).  
   

--- a/libraries/netapi32/NetUserChangePassword.md
+++ b/libraries/netapi32/NetUserChangePassword.md
@@ -5,7 +5,7 @@ Group: [Network Management](../../functions_group.md#Network_Management)  -  Lib
 ***  
 
 
-#### Changes user`s password for a specified network server or domain.
+#### Changes user's password for a specified network server or domain.
 
 ***  
 

--- a/libraries/shell32/SHGetFileInfo.md
+++ b/libraries/shell32/SHGetFileInfo.md
@@ -112,7 +112,7 @@ All system icons can be accessed through this function and drawn, for example, o
 ![](../../images/sysimagelist.png)  
 
 * * *  
-As MSDN suggests, the SHGetFileInfo may not be the best way, even if the simplest, to retrieve an object`s icon. A more flexible and efficient way is to use <a href="http://msdn.microsoft.com/en-us/library/bb761854(v=vs.85).aspx">IExtractIcon Interface</a>. The Shell uses IExtractIcon to retrieve icons when it displays the contents of a folder.  
+As MSDN suggests, the SHGetFileInfo may not be the best way, even if the simplest, to retrieve an object's icon. A more flexible and efficient way is to use <a href="http://msdn.microsoft.com/en-us/library/bb761854(v=vs.85).aspx">IExtractIcon Interface</a>. The Shell uses IExtractIcon to retrieve icons when it displays the contents of a folder.  
   
 ***  
 

--- a/libraries/shell32/ShellExecuteEx.md
+++ b/libraries/shell32/ShellExecuteEx.md
@@ -42,7 +42,7 @@ Returns TRUE if successful, or FALSE otherwise.
 
 ## Comments:
 <Strong>lpVerb</Strong> in <a href="http://msdn.microsoft.com/library/default.asp?url=/library/en-us/shellcc/platform/shell/reference/structures/shellexecuteinfo.asp">SHELLEXECUTEINFO</a> Structure:  
-String, referred to as a verb, that specifies the action to be performed. The set of available verbs depends on the particular file or folder. Generally, the actions available from an object`s shortcut menu are available verbs.  
+String, referred to as a verb, that specifies the action to be performed. The set of available verbs depends on the particular file or folder. Generally, the actions available from an object's shortcut menu are available verbs.  
   
 ```foxpro
 cBuffer = num2dword(INFO_SIZE) +;  
@@ -72,7 +72,7 @@ Opens the file specified by the lpFile parameter. The file can be an executable 
 Prints the document file specified by lpFile.  
   
 <Strong>properties</Strong>  
-Displays the file or folder`s properties.  
+Displays the file or folder's properties.  
   
 ***  
 

--- a/libraries/user32/ActivateKeyboardLayout.md
+++ b/libraries/user32/ActivateKeyboardLayout.md
@@ -46,7 +46,7 @@ If the function succeeds, the return value is the previous input locale identifi
 
 
 ## Comments:
-Windows 2000/XP: Activates the specified locale identifier for the entire process and sends the WM_INPUTLANGCHANGE message to the current thread`s Focus or Active window.  
+Windows 2000/XP: Activates the specified locale identifier for the entire process and sends the WM_INPUTLANGCHANGE message to the current thread's Focus or Active window.  
   
 ***  
 

--- a/libraries/user32/GetSystemMetrics.md
+++ b/libraries/user32/GetSystemMetrics.md
@@ -58,7 +58,7 @@ The SM_REMOTESESSION system metric is used in a Terminal Services environment. I
   
 The SM_REMOTECONTROL is used in a Terminal Services environment. Its value is nonzero if the current session is remotely controlled; otherwise, 0.  
   
-Read post <a href="http://blogs.msdn.com/calvin_hsia/archive/2006/01/11/511639.aspx">Detecting Workstation state changes</a> in Calvin Hsia`s weblog.  
+Read post <a href="http://blogs.msdn.com/calvin_hsia/archive/2006/01/11/511639.aspx">Detecting Workstation state changes</a> in Calvin Hsia's weblog.  
   
 * * *  
 System Metrics Foundation Class included in VFP8 and 9 installations provides access to system metric information as mousewheel present, number of mouse buttons, and number of monitors are provided with the class, but any valid system metric can be queried.  

--- a/libraries/user32/PaintDesktop.md
+++ b/libraries/user32/PaintDesktop.md
@@ -38,7 +38,7 @@ If the function succeeds, the return value is nonzero.
 
 
 ## Comments:
-You may call this function from within the Paint event of a form and see what happens to form`s native controls, which controls are windowless by definition.  
+You may call this function from within the Paint event of a form and see what happens to form's native controls, which controls are windowless by definition.  
   
 ***  
 

--- a/libraries/user32/SetWindowsHookEx.md
+++ b/libraries/user32/SetWindowsHookEx.md
@@ -62,7 +62,7 @@ Though when called from FLL or DLL library, the SetWindowsHookEx can enable VFP 
 For example, provided a certain windows hook set, each following MESSAGEBOX() dialog within current VFP session would appear not centered but instead would automatically position itself at the specified screen location.  
   
 * * *  
-Highly recommended reading: Craig Boyd`s SPS blog entry <a href="http://www.sweetpotatosoftware.com/spsblog/2005/08/07/BindEventOnSteroids.aspx">BindEvent on Steroids</a>.  
+Highly recommended reading: Craig Boyd's SPS blog entry <a href="http://www.sweetpotatosoftware.com/spsblog/2005/08/07/BindEventOnSteroids.aspx">BindEvent on Steroids</a>.  
   
 ***  
 

--- a/libraries/wininet/InternetCloseHandle.md
+++ b/libraries/wininet/InternetCloseHandle.md
@@ -22,7 +22,7 @@ Group: [Internet Functions (WinInet)](../../functions_group.md#Internet_Function
 [How to retrieve the size of a remote file (FTP)](../../samples/sample_069.md)  
 [How to remove FTP directory](../../samples/sample_070.md)  
 [How to delete file on FTP server](../../samples/sample_071.md)  
-[How to download this reference`s archive through WinInet functions using InternetOpenUrl](../../samples/sample_110.md)  
+[How to download this reference's archive through WinInet functions using InternetOpenUrl](../../samples/sample_110.md)  
 [Custom HttpRequest class (WinINet)](../../samples/sample_185.md)  
 [Using InternetSetFilePointer when resuming interrupted download from the Internet](../../samples/sample_191.md)  
 [Reading list of folders and files on FTP server](../../samples/sample_340.md)  

--- a/libraries/wininet/InternetOpen.md
+++ b/libraries/wininet/InternetOpen.md
@@ -22,7 +22,7 @@ Group: [Internet Functions (WinInet)](../../functions_group.md#Internet_Function
 [How to retrieve the size of a remote file (FTP)](../../samples/sample_069.md)  
 [How to remove FTP directory](../../samples/sample_070.md)  
 [How to delete file on FTP server](../../samples/sample_071.md)  
-[How to download this reference`s archive through WinInet functions using InternetOpenUrl](../../samples/sample_110.md)  
+[How to download this reference's archive through WinInet functions using InternetOpenUrl](../../samples/sample_110.md)  
 [Custom HttpRequest class (WinINet)](../../samples/sample_185.md)  
 [Using InternetSetFilePointer when resuming interrupted download from the Internet](../../samples/sample_191.md)  
 [Reading list of folders and files on FTP server](../../samples/sample_340.md)  

--- a/libraries/wininet/InternetOpenUrl.md
+++ b/libraries/wininet/InternetOpenUrl.md
@@ -10,7 +10,7 @@ Group: [Internet Functions (WinInet)](../../functions_group.md#Internet_Function
 
 
 ## Code examples:
-[How to download this reference`s archive through WinInet functions using InternetOpenUrl](../../samples/sample_110.md)  
+[How to download this reference's archive through WinInet functions using InternetOpenUrl](../../samples/sample_110.md)  
 [Using InternetSetFilePointer when resuming interrupted download from the Internet](../../samples/sample_191.md)  
 
 ## Declaration:

--- a/libraries/wininet/InternetReadFile.md
+++ b/libraries/wininet/InternetReadFile.md
@@ -13,7 +13,7 @@ Group: [Internet Functions (WinInet)](../../functions_group.md#Internet_Function
 ## Code examples:
 [Using FtpCommand](../../samples/sample_059.md)  
 [Downloading files from the FTP server using InternetReadFile](../../samples/sample_063.md)  
-[How to download this reference`s archive through WinInet functions using InternetOpenUrl](../../samples/sample_110.md)  
+[How to download this reference's archive through WinInet functions using InternetOpenUrl](../../samples/sample_110.md)  
 [Custom HttpRequest class (WinINet)](../../samples/sample_185.md)  
 [Using InternetSetFilePointer when resuming interrupted download from the Internet](../../samples/sample_191.md)  
 [Custom FTP Class for Visual FoxPro application](../../samples/sample_344.md)  

--- a/samples/sample_088.md
+++ b/samples/sample_088.md
@@ -91,7 +91,7 @@ This is an output from call to CryptBinaryToString with *dwFlags* set to CRYPT_S
 ![](../images/crypt_string_hex.png)
 
 * * *  
-From *Burkhard Stiller`s* VFP Blog:  
+From *Burkhard Stiller's* VFP Blog:  
 <a href="http://myvfpblog.blogspot.com/2007/10/encoded-your-images-base64-binary.html">Another way to encode and store picture-data inside your classes</a> -- relates to base64 encoding, and is an interesting sample of code by itself.  
   
 ***  

--- a/samples/sample_110.md
+++ b/samples/sample_110.md
@@ -1,6 +1,6 @@
 [<img src="../images/home.png"> Home ](https://github.com/VFPX/Win32API)  
 
-# How to download this reference`s archive through WinInet functions using InternetOpenUrl
+# How to download this reference's archive through WinInet functions using InternetOpenUrl
 
 ## Before you begin:
 Check [similar example](sample_175.md) based on URL Monikers functions.  

--- a/samples/sample_206.md
+++ b/samples/sample_206.md
@@ -74,7 +74,7 @@ PROCEDURE declare
 [GetModuleFileName](../libraries/kernel32/GetModuleFileName.md)  
 
 ## Comment:
-First this code retrieves the handle to the icon (index=0) for the VFP executable module. Then it uses the GetIconInfo function to obtain some of this icon`s properties.  
+First this code retrieves the handle to the icon (index=0) for the VFP executable module. Then it uses the GetIconInfo function to obtain some of this icon's properties.  
   
 ***  
 

--- a/samples/sample_228.md
+++ b/samples/sample_228.md
@@ -3,7 +3,7 @@
 # How to make the caption of a VFP application flashing in the Windows task bar
 
 ## Before you begin:
-This code sample shows how to turn user to the monitor`s screen by flashing the icon of an application in the Windows taskbar. There are several other ways of  alerting the user using various visual effects:  
+This code sample shows how to turn user to the monitor's screen by flashing the icon of an application in the Windows taskbar. There are several other ways of  alerting the user using various visual effects:  
 
 * [Flashing caption of a VFP application in the Windows task bar using FlashWindowEx](sample_271.md)  
 * [Shaking VFP form controls](sample_526.md)  

--- a/samples/sample_234.md
+++ b/samples/sample_234.md
@@ -9,7 +9,7 @@ Like TCP (Transmission Control Protocol), UDP is used with IP (the Internet Prot
 
 Unlike TCP, UDP is connectionless and does not guarantee reliable communication; the application itself must process any errors and check for reliable delivery.  
 
-The UDP listener table contains information about this computer`s UDP end-points on which a local application is currently accepting datagrams.  
+The UDP listener table contains information about this computer's UDP end-points on which a local application is currently accepting datagrams.  
 
 ![](../images/udptable.png)  
 

--- a/samples/sample_271.md
+++ b/samples/sample_271.md
@@ -3,7 +3,7 @@
 # Using FlashWindowEx to flash the taskbar button of the VFP application
 
 ## Before you begin:
-This code sample shows how to turn user to the monitor`s screen by flashing the icon of an application in the Windows taskbar. There are several other ways of  alerting the user using various visual effects:  
+This code sample shows how to turn user to the monitor's screen by flashing the icon of an application in the Windows taskbar. There are several other ways of  alerting the user using various visual effects:  
 
 * [Flashing caption of a VFP application in the Windows task bar using FlashWindow](sample_228.md)  
 * [Shaking VFP form controls](sample_526.md)  

--- a/samples/sample_323.md
+++ b/samples/sample_323.md
@@ -181,7 +181,7 @@ RETURN Asc(SUBSTR(lcBuffer, 1,1)) + ;
   
 [DragAcceptFiles](http://msdn.microsoft.com/en-us/library/windows/desktop/bb776406(v=vs.85).aspx) function -- registers whether a window accepts dropped files.  
   
-A good reading on the subject, Andrew MacNeill`s [Using Drag and Drop in your Applications](http://www.aksel.com/whitepapers/dragdrop.htm). The article explains the basics and the more of using FoxPro native OLEDragOver and OLEDragDrop events for dragging and dropping files from Explorer and Outlook windows.  
+A good reading on the subject, Andrew MacNeill's [Using Drag and Drop in your Applications](http://www.aksel.com/whitepapers/dragdrop.htm). The article explains the basics and the more of using FoxPro native OLEDragOver and OLEDragDrop events for dragging and dropping files from Explorer and Outlook windows.  
   
 ***  
 

--- a/samples/sample_385.md
+++ b/samples/sample_385.md
@@ -326,7 +326,7 @@ RETURN CHR(MOD(m.lnValue,256)) + CHR(INT(m.lnValue/256))
 [socket](../libraries/ws2_32/socket.md)  
 
 ## Comment:
-The sender email address can be anything. This approach somehow hides the sender`s identity. Of course, the actual ip address stays and can not be forged. By any means I do not encourage you to cheat on your recipients. Myself, I really hate spammers and unsolicited messages.  
+The sender email address can be anything. This approach somehow hides the sender's identity. Of course, the actual ip address stays and can not be forged. By any means I do not encourage you to cheat on your recipients. Myself, I really hate spammers and unsolicited messages.  
   
 This class can be easily modified for sending messages to multiple recipients.  
   

--- a/samples/sample_401.md
+++ b/samples/sample_401.md
@@ -311,7 +311,7 @@ You know about "Other Files" section inside the Project Manager. I think, that w
 * * *  
 At first, this code truncated each and every VFP executable it was applied to, making the executables unusable. Everything in the code seemed to be correct, all API functions were called properly. The problem appeared to be with the VFP executable format itself.   
   
-Good news came on Nov.23, 2005 with an article I spotted on Calvin Hsia`s WebLog <a href="http://blogs.msdn.com/calvin_hsia/archive/2005/09/02/460206.aspx">Strongly typed methods and properties</a>.   
+Good news came on Nov.23, 2005 with an article I spotted on Calvin Hsia's WebLog <a href="http://blogs.msdn.com/calvin_hsia/archive/2005/09/02/460206.aspx">Strongly typed methods and properties</a>.   
   
 Calvin preserves two last sections of the executable before modifying its resources; and appends them back after the EndUpdateResource succeeds. Looks like it solves the truncation problem.  
   

--- a/samples/sample_414.md
+++ b/samples/sample_414.md
@@ -4,7 +4,7 @@
 
 ## Before you begin:
 ![](../images/magnifier.png)  
-After you activate the magnifier the form`s part under the mouse cursor will be constantly redrawn on the main FoxPro window.  
+After you activate the magnifier the form's part under the mouse cursor will be constantly redrawn on the main FoxPro window.  
 
 See also:
 

--- a/samples/sample_482.md
+++ b/samples/sample_482.md
@@ -55,7 +55,7 @@ PROTECTED xpos, ypos
 	printername=""
 
 PROCEDURE ShowDialog(nX, nY)
-	* Victor Espinoza`s suggestion proves correct:
+	* Victor Espinoza's suggestion proves correct:
 	* locking drawing in the desktop window and unlocking it
 	* later in SetPosition method hides the "jump"
 	= LockWindowUpdate(GetDesktopWindow())

--- a/samples/sample_484.md
+++ b/samples/sample_484.md
@@ -370,7 +370,7 @@ The AVIStreamGetFrame returns the address of a decompressed video frame. It poin
 Practically, this is a bitmap file. All you have to do is to populate the BITMAPFILEHEADER structure and add it on top of the block. Then save the result to a file with "DIB" or "BMP" extension.  
   
 * * *  
-There is an issue not answered yet: the AVIStreamGetFrameOpen returns an error for some AVI files. Otherwise these are normal AVI files. I`m looking what can be done...  
+There is an issue not answered yet: the AVIStreamGetFrameOpen returns an error for some AVI files. Otherwise these are normal AVI files. I'm looking what can be done...  
   
 
 ***  

--- a/samples/sample_495.md
+++ b/samples/sample_495.md
@@ -264,14 +264,14 @@ PostMessage(hDocument, WM_SYSCOMMAND, SC_CLOSE, 0)
 where *hDocument* is the handle for a document window parented by the main Acrobat window.  
   
 * * *  
-Finally, I decided to go through using the Acrobat`s menu. First I obtained identifiers for several submenu popups and menu items, like *Close All, Exit, File, Window* etc. For that I used program code similar to [Reading structure of a menu attached to the main VFP window](sample_337.md) code sample.  
+Finally, I decided to go through using the Acrobat's menu. First I obtained identifiers for several submenu popups and menu items, like *Close All, Exit, File, Window* etc. For that I used program code similar to [Reading structure of a menu attached to the main VFP window](sample_337.md) code sample.  
   
 Once the identifier for a menu item is known, it is simple to create a virtual click on this item without even moving the mouse:   
 ```foxpro
 = SendMessage(hWindow, WM_COMMAND, nMenuItemID, 0)
 ```
 
-where *hWindow* is the main Acrobat window handle, and *nMenuItemID* is a menu item`s identifier. For example, identifier 6026 is assigned to *File - Exit* menu item.  
+where *hWindow* is the main Acrobat window handle, and *nMenuItemID* is a menu item's identifier. For example, identifier 6026 is assigned to *File - Exit* menu item.  
   
 * * *  
 An article called [A simple wrapper to control Acrobat Reader from your application](https://www.codeproject.com/articles/8763/a-simple-wrapper-to-control-acrobat-reader-from-yo) written by *seasidetech* explains how to use selected DDE messages to control the reader from outside.  

--- a/samples/sample_504.md
+++ b/samples/sample_504.md
@@ -324,7 +324,7 @@ Even if the alert window is always-on-top, sometimes it needs to be redrawn. It 
   
 To keep the code short and compatible not just with VFP9, I decided to add the Timer Control to redraw the window every second. Though I think it is possible to respond to WM_PAINT messages. I will check this opportunity later.  
   
-Another option I want to investigate is using the FoxPro form window instead of creating one with the CreateWindow API. The style and the extended style of the form, I think, can be modified to make it look and behave appropriately. And then the form`s Paint Event may come handy.  
+Another option I want to investigate is using the FoxPro form window instead of creating one with the CreateWindow API. The style and the extended style of the form, I think, can be modified to make it look and behave appropriately. And then the form's Paint Event may come handy.  
   
 * * *  
 The image looks a bit weird on the screen of my Toshiba notebook. There are small white speckles around the letters; a kind of residual left after the white color has been removed by the SetLayeredWindowAttributes call. Interesting enough, the artefact disappears gradually after several seconds, read: after the alert window is redrawn several times.  

--- a/samples/sample_508.md
+++ b/samples/sample_508.md
@@ -10,7 +10,7 @@ The SHFileOperation copies, deletes and moves a file or multiple files. A variet
 
 
 ## Before you begin:
-If you`ve been thinking about retiring ageing VFP commands COPY FILE and RENAME then give this code a try.  
+If you've been thinking about retiring ageing VFP commands COPY FILE and RENAME then give this code a try.  
 
 ![](../images/copyfilewithprogress.png)  
 

--- a/samples/sample_526.md
+++ b/samples/sample_526.md
@@ -5,14 +5,14 @@
 ## Note that this document contains some links to the old news2news website which does not work at the moment. This material will be available sometime in the future.
 
 ## Short description:
-Shuddering control may appear a good way to get user`s immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
+Shuddering control may appear a good way to get user's immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
 ***  
 
 
 ## Before you begin:
 The code is based on [custom GDI+ class](sample_450.md). Download the class module first and save it in **gdiplus.prg** file.   
 
-Shuddering control may appear a good way to get user`s immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
+Shuddering control may appear a good way to get user's immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
 
 It starts with creating a sequence of frames and storing them in memory. Each frame is an image of the control rotated by a certain small angle. When a shaking time comes, the actual control becomes hidden and a timer starts drawing frames upon its location. In this way, an illusion is created of the control shaking with the amplitude fading in a few seconds.  
 

--- a/samples/sample_527.md
+++ b/samples/sample_527.md
@@ -3,14 +3,14 @@
 # How to make a VFP form fading out when released (GDI+ version)
 
 ## Short description:
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ***  
 
 
 ## Before you begin:
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have a form slowly (or less slowly) fading out?  
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have a form slowly (or less slowly) fading out?  
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 
@@ -174,7 +174,7 @@ DEFINE CLASS FadingWindow As Session
 	cwinwidth=0
 	cwinheight=0
 
-	origbmp=NULL  && gdi+ bitmap storing the form`s image
+	origbmp=NULL  && gdi+ bitmap storing the form's image
 	hgraphics=NULL && gdi+ graphics object
 	alphachannel=0xff  && alpha channel value
 
@@ -315,14 +315,14 @@ ENDDEFINE
 ## Comment:
 So the succession of events should be as follows:  
   
-1. form`s Destroy event occurs  
-1. form`s image is copied into a memory object (within the Destroy, the form and all controls are still visible, though some doubts exist about PageFrame control and ActiveX controls)  
+1. form's Destroy event occurs  
+1. form's image is copied into a memory object (within the Destroy, the form and all controls are still visible, though some doubts exist about PageFrame control and ActiveX controls)  
 1. a cover window is created and placed exactly on the same spot where the original VFP form is  
 1. a timer is turned on and gradually changes the opacity of the covering window from 255 to 0By the first tick of the timer the original form does not exist anymore, the Destroy has completed its job.   
   
 Certainly, the timer and an object responsible for performing steps 2 to 4 must reside outside of the form. That probably can be a master form or _SCREEN container.  
   
-This approach works with all VFP forms, with top-level as well as with child ones. Here is a code that has to be called in the form`s Destroy event
+This approach works with all VFP forms, with top-level as well as with child ones. Here is a code that has to be called in the form's Destroy event
 
 ```foxpro
 IF VARTYPE(_screen.FormFader1) <> "O"  

--- a/samples/sample_528.md
+++ b/samples/sample_528.md
@@ -3,14 +3,14 @@
 # How to make a VFP form fading out when released (GDI version)
 
 ## Short description:
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ***  
 
 
 ## Before you begin:
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have a form slowly (or less slowly) fading out?  
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have a form slowly (or less slowly) fading out?  
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 

--- a/samples/sample_530.md
+++ b/samples/sample_530.md
@@ -5,7 +5,7 @@
 ## Short description:
 When the list of files and folders is to be displayed inside a VFP form, the ListBox VFP control and the ListView ActiveX control are probably the first two candidates for the job. 
 
-The ListBox`s presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
+The ListBox's presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
 
 ![](../images/sysimagelist.png)
 
@@ -16,7 +16,7 @@ And an imminent question arises: where are those icons stored and how to put the
 ## Before you begin:
 When the list of files and folders is to be displayed inside a VFP form, the ListBox VFP control and the ListView ActiveX control are probably the first two candidates for the job.   
 
-The ListBox`s presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.  
+The ListBox's presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.  
 
 ![](../images/sysimagelist_compare.png)  
 And then one start thinking, where are those icons stored and how to put them to work?  

--- a/samples/sample_536.md
+++ b/samples/sample_536.md
@@ -304,7 +304,7 @@ Comparing to other ways of interprocess communication (named pipes, mailslots, W
   
 * * *  
 http://blogs.msdn.com/oldnewthing/archive/2003/12/11/56043.aspx  
-> if you need to pass more than 32767 characters of information to a child process, you`ll have to use something other than the command line. 
+> if you need to pass more than 32767 characters of information to a child process, you'll have to use something other than the command line. 
 ***
 
 Articles:  

--- a/samples/sample_546.md
+++ b/samples/sample_546.md
@@ -11,7 +11,7 @@ The pictures taken with modern digital cameras are usually wider and taller than
 ![](../images/picturescroll.jpg)    
 1920 by 1080 pixels, which requires fairly regular video card and monitor these days, is only 2 megapixel size. Uncropped 10.1 megapixel shot taken with Canon EOS is 3888 by 2592 pixels -- roughly two times taller and wider.  
 
-To view so large picture in its original size you need a scrollable form. Normally it is programmed by setting the form`s ScrollBars to 3 and having the image control`s Stretch property set to 0 (default). The picture automatically stretches the image control. After that any part of it can be conveniently scrolled to with the form`s two scroll bars.  
+To view so large picture in its original size you need a scrollable form. Normally it is programmed by setting the form's ScrollBars to 3 and having the image control's Stretch property set to 0 (default). The picture automatically stretches the image control. After that any part of it can be conveniently scrolled to with the form's two scroll bars.  
 
 ![](../images/scrollableform.jpg)  
 
@@ -19,7 +19,7 @@ An example demonstrating this approach (the picture above) is provided in the ar
 ***  
 Except with the scroll bars, I would also like scrolling the image by simply clicking on it and dragging (like in Picasa, for example). The example from Microsoft can certainly be modified to handle the MouseMove and MouseWheel events of the Image control.  
 
-Finding less fun in improving someone else`s code I decided on programming similar functionality using the GDI+ library. The results came not bad indeed.  
+Finding less fun in improving someone else's code I decided on programming similar functionality using the GDI+ library. The results came not bad indeed.  
 
 See also:
 
@@ -137,7 +137,7 @@ PROCEDURE AdjustClippingRegion
 
 		* create Graphics object from the device context
 		* of the form; note that the GetDC is used (not GetWindowDC),
-		* the output affects only the form`s client area
+		* the output affects only the form's client area
 		.hDC = GetDC(.HWnd)
 		.formgraphics = CREATEOBJECT("graphics", .hDC)
 
@@ -145,7 +145,7 @@ PROCEDURE AdjustClippingRegion
 		STORE 0 TO .OffsetX, .OffsetY
 
 		* the clipping is required only if the image
-		* display area is smaller than the form`s client area
+		* display area is smaller than the form's client area
 *!*			= GdipSetClipRectI(.formgraphics.graphics,;
 *!*				0, 0, .Width, .Height, 0)
 

--- a/samples/sample_578.md
+++ b/samples/sample_578.md
@@ -401,7 +401,7 @@ The effect is achieved by placing a semi-transparent window below a top-level VF
 
 ![](../images/lightbox.png)
 
-VFP application can change window`s transparency and color.  
+VFP application can change window's transparency and color.  
   
 ***  
 

--- a/samples/sample_582.md
+++ b/samples/sample_582.md
@@ -92,7 +92,7 @@ PROCEDURE declare
 ## Comment:
 ![](../images/onscreenkbdclass.png)
 
-On-Screen Keyboard`s window class name is "OSKMainClass". Knowing this, a VFP application can test the visibility of the On-Screen Keyboard by calling the FindWindow. By calling the SetWindowPos or similar API function, the virtual keyboard can be shown, hidden, or positioned at a specified point on the screen.  
+On-Screen Keyboard's window class name is "OSKMainClass". Knowing this, a VFP application can test the visibility of the On-Screen Keyboard by calling the FindWindow. By calling the SetWindowPos or similar API function, the virtual keyboard can be shown, hidden, or positioned at a specified point on the screen.  
   
 ***  
 

--- a/samples_alphabetical.md
+++ b/samples_alphabetical.md
@@ -221,7 +221,7 @@ The SHFileOperation copies, deletes and moves a file or multiple files. A variet
 ## [Displaying the associated icons and descriptions for files and folders](samples/sample_530.md)
 When the list of files and folders is to be displayed inside a VFP form, the ListBox VFP control and the ListView ActiveX control are probably the first two candidates for the job. 
 
-The ListBox`s presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
+The ListBox's presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
 
 <img src="images/sysimagelist.png" width=507 height=338>
 And an imminent question arises: where are those icons stored and how to put them to work?  
@@ -375,7 +375,7 @@ This code sample explains how to load an image from a file, crop it using GdipDr
 ## [GDI+: custom control, base class](samples/sample_599.md)
 
 ## [GDI+: how to make VFP controls visually shake and shudder](samples/sample_526.md)
-Shuddering control may appear a good way to get user`s immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
+Shuddering control may appear a good way to get user's immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
 ## [GDI+: printing image file](samples/sample_452.md)
 
 ## [GDI+: reading and writing metadata in JPEG and TIFF files](samples/sample_461.md)
@@ -487,7 +487,7 @@ The Windows OS has a mechanism that allows to notify a window when the content o
 
 ## [How to download a file from the FTP server using FtpGetFile](samples/sample_043.md)
 
-## [How to download this reference`s archive through WinInet functions using InternetOpenUrl](samples/sample_110.md)
+## [How to download this reference's archive through WinInet functions using InternetOpenUrl](samples/sample_110.md)
 
 ## [How to drag a Form not using its Titlebar or Caption](samples/sample_195.md)
 
@@ -533,11 +533,11 @@ This code shows how VFP top-level form can get notified upon its menu item selec
 ## [How to load a user profile](samples/sample_602.md)
 
 ## [How to make a VFP form fading out when released (GDI version)](samples/sample_528.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to make a VFP form fading out when released (GDI+ version)](samples/sample_527.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to make application automatically close all documents it opened](samples/sample_491.md)

--- a/samples_group.md
+++ b/samples_group.md
@@ -38,7 +38,7 @@ This code sample shows how to load an image file (BMP, GIF, JPEG, PNG, TIFF), sc
 ## [GDI+: copying to the Clipboard (a) image of active FoxPro window/form, (b) image file](samples/sample_457.md)
 
 ## [GDI+: how to make VFP controls visually shake and shudder](samples/sample_526.md)
-Shuddering control may appear a good way to get user`s immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
+Shuddering control may appear a good way to get user's immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
 ## [GDI+: saving image of FoxPro form to graphics file (BMP, GIF, JPG, PNG, TIF)](samples/sample_454.md)
 
 ## [GDI+: sending image of FoxPro form to printer](samples/sample_455.md)
@@ -49,11 +49,11 @@ It all started with a question I have noticed in the Universal Thread Visual Fox
 ## [How to copy the image of a form to the Clipboard using Bitmap API functions](samples/sample_091.md)
 
 ## [How to make a VFP form fading out when released (GDI version)](samples/sample_528.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to make a VFP form fading out when released (GDI+ version)](samples/sample_527.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to print FoxPro form](samples/sample_158.md)
@@ -89,7 +89,7 @@ An obvious way of doing that is covering the form with another window, which hol
 ## [Displaying dimmed window behind VFP top-level form](samples/sample_578.md)
 
 ## [How to make a VFP form fading out when released (GDI version)](samples/sample_528.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to put a horizontal text scrolling on the form (a news line, marquee)](samples/sample_352.md)
@@ -299,7 +299,7 @@ This code sample shows how to load an image file (BMP, GIF, JPEG, PNG, TIFF), sc
 ## [Displaying the associated icons and descriptions for files and folders](samples/sample_530.md)
 When the list of files and folders is to be displayed inside a VFP form, the ListBox VFP control and the ListView ActiveX control are probably the first two candidates for the job. 
 
-The ListBox`s presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
+The ListBox's presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
 
 <img src="images/sysimagelist.png" width=507 height=338>
 And an imminent question arises: where are those icons stored and how to put them to work?  
@@ -336,7 +336,7 @@ After releasing the mouse button, the image scrolling coninues while deceleratin
 ## [GDI+: custom control, base class](samples/sample_599.md)
 
 ## [GDI+: how to make VFP controls visually shake and shudder](samples/sample_526.md)
-Shuddering control may appear a good way to get user`s immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
+Shuddering control may appear a good way to get user's immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
 ## [GDI+: printing image file](samples/sample_452.md)
 
 ## [GDI+: saving image of FoxPro form to graphics file (BMP, GIF, JPG, PNG, TIF)](samples/sample_454.md)
@@ -364,11 +364,11 @@ This code sample shows how to hide the Caption and the border of FoxPro form and
 ## [How to find which fonts Windows uses for drawing captions, menus and message boxes](samples/sample_556.md)
 Calling SystemParametersInfo with SPI_GETNONCLIENTMETRICS input parameter populates the NONCLIENTMETRICS structure. This structure contains the metrics associated with the nonclient area of a nonminimized window. Among the metrics included are the settings for 5 fonts, the OS uses for drawing captions, small captions, menus, status bars and message boxes.  
 ## [How to make a VFP form fading out when released (GDI version)](samples/sample_528.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to make a VFP form fading out when released (GDI+ version)](samples/sample_527.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to play AVI file on the _screen](samples/sample_430.md)
@@ -610,7 +610,7 @@ The following example presents session class *CacheEntry* and collection class *
 
 ## [How to display the port-configuration dialog box for a port on the specified server](samples/sample_362.md)
 
-## [How to download this reference`s archive through WinInet functions using InternetOpenUrl](samples/sample_110.md)
+## [How to download this reference's archive through WinInet functions using InternetOpenUrl](samples/sample_110.md)
 
 ## [How to enable the SE_SHUTDOWN_NAME privilege for the application](samples/sample_552.md)
 To shut down or to reboot the system (API calls ExitWindowsEx, InitiateShutdown and others) the process must have the SE_SHUTDOWN_NAME privilege (default behaviour on Vista).  
@@ -928,7 +928,7 @@ The code shows how to obtain number of cylinders, tracks, sectors and clusters f
 # ![](images/fox1.png) Filled Shape group
 
 ## [How to make a VFP form fading out when released (GDI version)](samples/sample_528.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to put a horizontal text scrolling on the form (a news line, marquee)](samples/sample_352.md)
@@ -1206,7 +1206,7 @@ This code sample shows how to load an image file (BMP, GIF, JPEG, PNG, TIFF), sc
 ## [Displaying the associated icons and descriptions for files and folders](samples/sample_530.md)
 When the list of files and folders is to be displayed inside a VFP form, the ListBox VFP control and the ListView ActiveX control are probably the first two candidates for the job. 
 
-The ListBox`s presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
+The ListBox's presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
 
 <img src="images/sysimagelist.png" width=507 height=338>
 And an imminent question arises: where are those icons stored and how to put them to work?  
@@ -1256,7 +1256,7 @@ The following example presents session class *CacheEntry* and collection class *
 
 ## [How to download a file from the FTP server using FtpGetFile](samples/sample_043.md)
 
-## [How to download this reference`s archive through WinInet functions using InternetOpenUrl](samples/sample_110.md)
+## [How to download this reference's archive through WinInet functions using InternetOpenUrl](samples/sample_110.md)
 
 ## [How to enumerate cookies and URL History entries in the cache of the local computer](samples/sample_350.md)
 
@@ -1819,7 +1819,7 @@ The SetLayeredWindowAttributes function can be used to define the transparency c
 ## [Displaying the associated icons and descriptions for files and folders](samples/sample_530.md)
 When the list of files and folders is to be displayed inside a VFP form, the ListBox VFP control and the ListView ActiveX control are probably the first two candidates for the job. 
 
-The ListBox`s presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
+The ListBox's presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
 
 <img src="images/sysimagelist.png" width=507 height=338>
 And an imminent question arises: where are those icons stored and how to put them to work?  
@@ -2022,7 +2022,7 @@ The SetLayeredWindowAttributes function can be used to define the transparency c
 ## [Displaying the associated icons and descriptions for files and folders](samples/sample_530.md)
 When the list of files and folders is to be displayed inside a VFP form, the ListBox VFP control and the ListView ActiveX control are probably the first two candidates for the job. 
 
-The ListBox`s presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
+The ListBox's presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
 
 <img src="images/sysimagelist.png" width=507 height=338>
 And an imminent question arises: where are those icons stored and how to put them to work?  
@@ -2051,7 +2051,7 @@ After releasing the mouse button, the image scrolling coninues while deceleratin
 ## [GDI+: copying to the Clipboard (a) image of active FoxPro window/form, (b) image file](samples/sample_457.md)
 
 ## [GDI+: how to make VFP controls visually shake and shudder](samples/sample_526.md)
-Shuddering control may appear a good way to get user`s immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
+Shuddering control may appear a good way to get user's immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
 ## [GDI+: saving image of FoxPro form to graphics file (BMP, GIF, JPG, PNG, TIF)](samples/sample_454.md)
 
 ## [GDI+: sending image of FoxPro form to printer](samples/sample_455.md)
@@ -2070,11 +2070,11 @@ This code sample shows how to hide the Caption and the border of FoxPro form and
 ## [How to find which fonts Windows uses for drawing captions, menus and message boxes](samples/sample_556.md)
 Calling SystemParametersInfo with SPI_GETNONCLIENTMETRICS input parameter populates the NONCLIENTMETRICS structure. This structure contains the metrics associated with the nonclient area of a nonminimized window. Among the metrics included are the settings for 5 fonts, the OS uses for drawing captions, small captions, menus, status bars and message boxes.  
 ## [How to make a VFP form fading out when released (GDI version)](samples/sample_528.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to make a VFP form fading out when released (GDI+ version)](samples/sample_527.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to play AVI file on the _screen](samples/sample_430.md)
@@ -2339,11 +2339,11 @@ The SetLayeredWindowAttributes function can be used to define the transparency c
 This code sample shows how to hide the Caption and the border of FoxPro form and replace them with eight Image controls and one Label control. The form is resizable, closable and can be clicked on its caption and dragged.
   
 ## [How to make a VFP form fading out when released (GDI version)](samples/sample_528.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to make a VFP form fading out when released (GDI+ version)](samples/sample_527.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [Placing On-screen Alert on top of all windows](samples/sample_504.md)
@@ -2557,7 +2557,7 @@ The SHFileOperation copies, deletes and moves a file or multiple files. A variet
 ## [Displaying the associated icons and descriptions for files and folders](samples/sample_530.md)
 When the list of files and folders is to be displayed inside a VFP form, the ListBox VFP control and the ListView ActiveX control are probably the first two candidates for the job. 
 
-The ListBox`s presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
+The ListBox's presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
 
 <img src="images/sysimagelist.png" width=507 height=338>
 And an imminent question arises: where are those icons stored and how to put them to work?  
@@ -2752,7 +2752,7 @@ The SetLayeredWindowAttributes function can be used to define the transparency c
 ## [Displaying the associated icons and descriptions for files and folders](samples/sample_530.md)
 When the list of files and folders is to be displayed inside a VFP form, the ListBox VFP control and the ListView ActiveX control are probably the first two candidates for the job. 
 
-The ListBox`s presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
+The ListBox's presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
 
 <img src="images/sysimagelist.png" width=507 height=338>
 And an imminent question arises: where are those icons stored and how to put them to work?  
@@ -2761,7 +2761,7 @@ And an imminent question arises: where are those icons stored and how to put the
 ## [Finding out if the current user is the Guest account](samples/sample_566.md)
 In this code sample, the CurrentUser class wraps call to the NetUserGetInfo that populates USER_INFO_1 structure. The usri1_priv member of this struture indicates if the user account is Guest or Admin.  
 ## [GDI+: how to make VFP controls visually shake and shudder](samples/sample_526.md)
-Shuddering control may appear a good way to get user`s immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
+Shuddering control may appear a good way to get user's immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
 ## [How to Start a Process as Another User (NT/XP/2K)](samples/sample_426.md)
 
 ## [How to display Windows On-Screen Keyboard](samples/sample_582.md)
@@ -2772,11 +2772,11 @@ This code sample shows how to hide the Caption and the border of FoxPro form and
 ## [How to find which fonts Windows uses for drawing captions, menus and message boxes](samples/sample_556.md)
 Calling SystemParametersInfo with SPI_GETNONCLIENTMETRICS input parameter populates the NONCLIENTMETRICS structure. This structure contains the metrics associated with the nonclient area of a nonminimized window. Among the metrics included are the settings for 5 fonts, the OS uses for drawing captions, small captions, menus, status bars and message boxes.  
 ## [How to make a VFP form fading out when released (GDI version)](samples/sample_528.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to make a VFP form fading out when released (GDI+ version)](samples/sample_527.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to make application automatically close all documents it opened](samples/sample_491.md)
@@ -2867,7 +2867,7 @@ After releasing the mouse button, the image scrolling coninues while deceleratin
 ## [GDI+: custom Clock Control](samples/sample_597.md)
 
 ## [GDI+: how to make VFP controls visually shake and shudder](samples/sample_526.md)
-Shuddering control may appear a good way to get user`s immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
+Shuddering control may appear a good way to get user's immediate attention. For example, when Purchase Order form opens, and the shipping date is not entered or overdue, the textbox hosting this value may start vibrate and thus can be easily spotted by the user.  
 ## [HOWTO: Use the Win32 API to Access File Dates and Times](samples/sample_177.md)
 
 ## [How to delete IE cookies, clear IE history and delete files in Temporary Internet Files directory](samples/sample_471.md)
@@ -3001,11 +3001,11 @@ The AdobeReaderSDIWindow class is able to virtually "click on" an item in the ma
 ## [How to hot-track menu item selection in top-level form (requires VFP9)](samples/sample_521.md)
 This code shows how VFP top-level form can get notified upon its menu item selection. Note that the menu item is not clicked on, but selected by the mouse hovering over it or by the keyboard.  
 ## [How to make a VFP form fading out when released (GDI version)](samples/sample_528.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to make a VFP form fading out when released (GDI+ version)](samples/sample_527.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to position the GETPRINTER() dialog](samples/sample_482.md)
@@ -3119,7 +3119,7 @@ The SetLayeredWindowAttributes function can be used to define the transparency c
 ## [Displaying the associated icons and descriptions for files and folders](samples/sample_530.md)
 When the list of files and folders is to be displayed inside a VFP form, the ListBox VFP control and the ListView ActiveX control are probably the first two candidates for the job. 
 
-The ListBox`s presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
+The ListBox's presentation style can only be described as the minimalistic :) , while the ListView shows items in much fancier manner, and can even accompany each file and folder with an icon.
 
 <img src="images/sysimagelist.png" width=507 height=338>
 And an imminent question arises: where are those icons stored and how to put them to work?  
@@ -3138,11 +3138,11 @@ The Windows OS has a mechanism that allows to notify a window when the content o
 ## [How to hot-track menu item selection in top-level form (requires VFP9)](samples/sample_521.md)
 This code shows how VFP top-level form can get notified upon its menu item selection. Note that the menu item is not clicked on, but selected by the mouse hovering over it or by the keyboard.  
 ## [How to make a VFP form fading out when released (GDI version)](samples/sample_528.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to make a VFP form fading out when released (GDI+ version)](samples/sample_527.md)
-When a VFP form is released, usually it disappears immediately. Wouldn`t it be nice to have the form slowly (or less slowly) fading out?
+When a VFP form is released, usually it disappears immediately. Wouldn't it be nice to have the form slowly (or less slowly) fading out?
 
 An obvious way of doing that is covering the form with another window, which holds the image of the original form. Once covered, the original form disappears. After that the covering window gradually changes its opacity (alpha channel) from opaque (255) to completely transparent (0).  
 ## [How to view icons stored in executable files (Icon Viewer) - II](samples/sample_019.md)


### PR DESCRIPTION
Replaced backticks (\`) with proper apostrophes (\') in contractions (like `I'm`) and possessives.
Inline code (\`code\`) and fenced code blocks (\`\`\`) were left untouched to preserve Markdown syntax.